### PR TITLE
Fix accessing destroyed secret

### DIFF
--- a/has_new_key/hasNewKey.go
+++ b/has_new_key/hasNewKey.go
@@ -35,7 +35,7 @@ func HandleHasNewKey(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write(responseBytes)
 			return
-		} else if keys[1] == requestKey {
+		} else if len(keys) > 1 && keys[1] == requestKey { // in case we don't have two keys to prevent crashes
 			log.Trace().Msg("key[1] == requestKey")
 			response := map[string]bool{"hasNewKey": false}
 			responseBytes, err := json.Marshal(response)

--- a/helper/api_key_retriver.go
+++ b/helper/api_key_retriver.go
@@ -27,11 +27,13 @@ func RetrievApiKeys() []string {
 		}
 		var apiKeys []string
 		for _, secret := range secretVersions.SecretVersions {
-			data, err := client.GetSecretData("apiKey", strconv.FormatUint(uint64(secret.Revision), 10))
-			apiKeys = append(apiKeys, string(data))
-			if err != nil {
-				/// Should also be impossible to not get the data if the rest is true
-				panic(err)
+			if secret.Status != "destroyed" {
+				data, err := client.GetSecretData("apiKey", strconv.FormatUint(uint64(secret.Revision), 10))
+				apiKeys = append(apiKeys, string(data))
+				if err != nil {
+					/// Should also be impossible to not get the data if the rest is true
+					panic(err)
+				}
 			}
 		}
 		return apiKeys


### PR DESCRIPTION
- Fix: Prevent adding destroyed secrets when getting api keys
- Chore: Add test to figure that out (maybe needs improvment?)
- Fix: Add check in case we have an outdated api key and only one key in store to just skip and return `hasNewKey:true`
to prevent crashs