### PR TITLE
Fix sign bytes not hash string

### DIFF
--- a/cronjob/go.mod
+++ b/cronjob/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21 // indirect

--- a/cronjob/go.sum
+++ b/cronjob/go.sum
@@ -1,3 +1,5 @@
+codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570 h1:TXbikPqa7YRtfU9vS6QJBg77pUvbEb6StRdZO8t1bEY=
+codeberg.org/gusted/mcaptcha v0.0.0-20220723083913-4f3072e1d570/go.mod h1:IIAjsijsd8q1isWX8MACefDEgTQslQ4stk2AeeTt3kM=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -50,7 +50,15 @@ func HandleSignature(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Bad Request"))
 		return
 	}
-	signatureBytes, err := signatureManager.SignData([]byte(holder.Data))
+	decodedHash, err := hex.DecodeString(holder.Data)
+	if err != nil {
+		log.Error().Msg("Bad Request, can't decode hash. Details: " + err.Error())
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Bad Request"))
+		return
+	}
+	signatureBytes, err := signatureManager.SignData(decodedHash)
 	if err != nil {
 		log.Error().Msg("Internal Server Error, can't sign data. Details: " + err.Error())
 		w.Header().Set("Content-Type", "text/plain")

--- a/util/generate_keys.go
+++ b/util/generate_keys.go
@@ -51,7 +51,7 @@ func saveKeys(key *ecdsa.PrivateKey, outPutDir string, outPutFileName string) er
 	}
 
 	bytes, err = x509.MarshalPKIXPublicKey(&key.PublicKey)
-	pubBloc := pem.Block{Type: "EC Public KEY", Bytes: bytes}
+	pubBloc := pem.Block{Type: "EC PUBLIC KEY", Bytes: bytes}
 	pubKeyFile, err := os.Create(outPutDir + "pub_" + outPutFileName + ".pem")
 	if err != nil {
 		return err

--- a/util/validate_signature.go
+++ b/util/validate_signature.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var signature string
+	var hash string
+	var pubKeyFilePath string
+	flag.StringVar(&signature, "signature", "", "Your signature")
+	flag.StringVar(&hash, "hash", "", "Your hash")
+	flag.StringVar(&pubKeyFilePath, "pbKey", "./pub.pem", "Public Key file path (.pem)")
+	flag.Parse()
+	err := verifySignature(signature, hash, pubKeyFilePath)
+	if err != nil {
+		fmt.Printf("Something went wrong %d", err)
+		return
+	}
+}
+
+func verifySignature(signature string, hash string, pubKeyFilePath string) error {
+	file, err := os.Open(pubKeyFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	pemFileInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	var size int64 = pemFileInfo.Size()
+	pemBytes := make([]byte, size)
+	buffer := bufio.NewReader(file)
+	_, err = buffer.Read(pemBytes)
+	if err != nil {
+		return err
+	}
+	//parse pem file
+	for block, rest := pem.Decode(pemBytes); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type == "EC PUBLIC KEY" || block.Type == "PUBLIC KEY" || block.Type == "EC Public KEY" {
+			pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+			if err != nil {
+				return err
+			}
+			ecdsaPubKey, ok := pubKey.(*ecdsa.PublicKey)
+			if !ok {
+				return fmt.Errorf("failed to parse ECDSA public key")
+			}
+			decodeSig, err := hex.DecodeString(signature)
+			if err != nil {
+				return err
+			}
+			bytes, err := hex.DecodeString(hash)
+			isValid := ecdsa.VerifyASN1(ecdsaPubKey, bytes, decodeSig)
+			fmt.Printf("\nIs signature valid: %v \n", isValid)
+			fmt.Println()
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Resolve issue that prevented signature validation on the web.

- Decode hex hash to bytes and not use `[]byte(hash)`
- Sign these bytes
- Add signature validation util script
- run `go mod tidy` in cronjob folder 